### PR TITLE
[fugu]: remove un-necessary extract files to make fugu build properly.

### DIFF
--- a/extract-files.sh
+++ b/extract-files.sh
@@ -251,8 +251,6 @@ COMMON_LIBS="
 	libaudioutils.so
 	libeng_wifi_ptest.so
 	libengclient.so
-	libjniNtvDev.so
-	libmbbms_tel_jni.so
 	libmorpho_facesolid.so
 	libstagefrighthw.so
 	libvbeffect.so


### PR DESCRIPTION
By checking Fugu partner's build, below two files are not necessary. 

  libjniNtvDev.so
  libmbbms_tel_jni.so

remove it from extract-files.sh
